### PR TITLE
Update the CoffeeLint error line pattern

### DIFF
--- a/flymake-coffee.el
+++ b/flymake-coffee.el
@@ -38,7 +38,7 @@ Must be a full path, so use `expand-file-name' if you want to use \"~\" etc."
     ("^SyntaxError: In \\([^,]+\\), \\(.+\\) on line \\([0-9]+\\)" 1 3 nil 2)
     ;; coffeelint
     ("SyntaxError: \\(.*\\) on line \\([0-9]+\\)" nil 2 nil 1)
-    ("\\(.+\\),\\([0-9]+\\),\\(\\(warn\\|error\\),.+\\)" 1 2 nil 3)))
+    ("\\(.+\\),\\([0-9]+\\),[0-9]*,\\(\\(warn\\|error\\),.+\\)" 1 2 nil 3)))
 
 (defun flymake-coffee-command (filename)
   "Construct a command that flymake can use to check coffeescript source."


### PR DESCRIPTION
This update reflects the latest changes in swang/coffeelint@6f59ff1e9cc3d7eb02f2f9f504d5aad58b95f44b which added a column to the CSV output.
